### PR TITLE
support for Watir 6.0

### DIFF
--- a/watircats.gemspec
+++ b/watircats.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'require_all', '~> 1.3'
   s.add_dependency 'thor', '~> 0.18'
-  s.add_dependency 'watir-webdriver', '~> 0.8'
+  s.add_dependency 'watir', '~> 6.0'
   s.add_dependency 'xml-simple', '~> 1.1'
   s.add_dependency 'haml', '~> 4.0'
   s.add_dependency 'psych', '~> 2.0'


### PR DESCRIPTION
watir-webdriver has been deprecated in favor of Watir 6.0. For people desiring to use this with the latest Selenium & Watir tools, this gem needs to reference `watir` and not `watir-webdriver` or else there will be conflicts. http://watir.github.io/watir-6-faq/#A